### PR TITLE
Bump Arduino Core to v3.0 to Match GCC12

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -81,6 +81,9 @@ upload_speed = 921600
 ; Check your board name at https://docs.platformio.org/en/latest/platforms/espressif32.html#boards
 ; [env:esp32]
 ; platform = espressif32 @ 6.5.0
+; platform_packages =
+;  platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0-alpha3
+;  platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-libs.git#idf-release/v5.1
 ; board = esp32dev
 ; Comment out this line below if you have any trouble uploading the firmware - and if it has a CP2102 on it (a square chip next to the usb port): change to 3000000 (3 million) for even faster upload speed
 ;upload_speed = 921600
@@ -97,11 +100,9 @@ upload_speed = 921600
 ;[env:esp32c3]
 ;platform = espressif32 @ 6.5.0
 ;platform_packages =
-;    toolchain-riscv32-esp @ 12.2.0
-;platform_version = 6.4.0
-;variant = esp32c3
+;  platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0-alpha3
+;  platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-libs.git#idf-release/v5.1
 ;build_flags =
 ;  ${env.build_flags}
 ;  -DESP32C3
-;  -march=rv32imc_zicsr_zifencei
 ;board = lolin_c3_mini

--- a/src/sensors/SensorManager.cpp
+++ b/src/sensors/SensorManager.cpp
@@ -57,21 +57,14 @@ namespace SlimeVR
             if (sclPin != activeSCL || sdaPin != activeSDA || !running) {
                 Wire.flush();
                 #if ESP32
-                    if (running) {}
-                    else {
-                        // Reset HWI2C to avoid being affected by I2CBUS reset
-                        Wire.end();
-                    }
+                    // Reset HWI2C to avoid being affected by I2CBUS reset
+                    Wire.end();
                     // Disconnect pins from HWI2C
                     pinMode(activeSCL, INPUT);
                     pinMode(activeSDA, INPUT);
 
-                    if (running) {
-                        i2c_set_pin(I2C_NUM_0, sdaPin, sclPin, false, false, I2C_MODE_MASTER);
-                    } else {
-                        Wire.begin(static_cast<int>(sdaPin), static_cast<int>(sclPin), I2C_SPEED);
-                        Wire.setTimeOut(150);
-                    }
+                    Wire.begin(static_cast<int>(sdaPin), static_cast<int>(sclPin), I2C_SPEED);
+                    Wire.setTimeOut(150);
                 #else
                     Wire.begin(static_cast<int>(sdaPin), static_cast<int>(sclPin));
                 #endif


### PR DESCRIPTION
Based on [https://github.com/platformio/platform-espressif32/issues/1225](https://github.com/platformio/platform-espressif32/issues/1225)
Since Arduino core v3 is based on IDF 5.1, this new PR may enable future ESP32 chips (C6/H4), while at the cost of potential compatibility issue like the removal of fast pin-swapping